### PR TITLE
Added overwrite functionality for the ClientDeploy Installer unzip st…

### DIFF
--- a/Setup/Program.cs
+++ b/Setup/Program.cs
@@ -39,7 +39,20 @@ namespace Setup
             }
 
             Console.Out.WriteLine("Extracting ClientDeploy Installer");
-            ZipFile.ExtractToDirectory(bootstrapper,cd);
+            ZipArchive archive = ZipFile.OpenRead(bootstrapper);
+            foreach (var archivedfile in archive.Entries)
+            {
+                string path = Path.Combine(cd, archivedfile.FullName);
+                if (archivedfile.Name == "")
+                {
+                    Console.Out.WriteLine($"... Creating Directory {path}");
+                    Directory.CreateDirectory(path);
+                    continue;
+                }
+                Console.Out.WriteLine($"... {(File.Exists(path) ? "Overwriting" : "Extracting")} File {archivedfile.FullName}" );
+                archivedfile.ExtractToFile(path, true);
+            }
+            archive.Dispose();
 
             Console.Out.WriteLine("Removing temporary file");
             File.Delete(bootstrapper);

--- a/Setup/Setup.csproj
+++ b/Setup/Setup.csproj
@@ -39,6 +39,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />


### PR DESCRIPTION
…ep (and more information output)

--> Setup doesn't crash anymore when ClientDeploy-file are already in the target directory